### PR TITLE
Restore private key handling broken since #21

### DIFF
--- a/chainbreaker/__init__.py
+++ b/chainbreaker/__init__.py
@@ -374,11 +374,9 @@ class Chainbreaker(object):
         if len(plain) == 0:
             return '', ''
 
-        # now we handle the unwrapping. we need to take the first 32 bytes,
-        # and reverse them.
-        revplain = bytes(reversed(plain[0:32]))
-        # now the real key gets found. */
-        plain = Chainbreaker._kcdecrypt(self.db_key, iv, revplain)
+        # reverse the plaintext before decrypting again
+        plain = bytes(reversed(plain))
+        plain = Chainbreaker._kcdecrypt(self.db_key, iv, plain)
 
         keyname = plain[:12]  # Copied Buffer when user click on right and copy a key on Keychain Access
         keyblob = plain[12:]


### PR DESCRIPTION
Private key decryption has been broken since #21 (specifically ca2a0dd4074cbf8813ea8e09bea3d9c42eac3537) due to a bad copy-paste.

Specifically this code is copied from the symmetric key handling and forces the private key's ciphertext to only be 32 bytes, which is not correct for asymmetric keys: https://github.com/n0fate/chainbreaker/blob/master/chainbreaker/__init__.py#L377-L381

Restoring the original logic with this PR in a plausible private key for me -- OpenSSL can decode & summarize it, and the modulus matches the certificate I expect it to go with.